### PR TITLE
Resolve issue from Set.remove change in SC3.14.0

### DIFF
--- a/Classes/Notator.sc
+++ b/Classes/Notator.sc
@@ -460,9 +460,13 @@ Notator {
 		"  <part-list>\n";
 
 		{
-			var part1 = [], part2 = [], part3 = [];
-			score[1].keys.remove(\bar)
-			.do { |partName|
+			var removeKeyword_bar, part1 = [], part2 = [], part3 = [];
+			removeKeyword_bar = if (Main.versionAtLeast(3, 14, 0)) {
+				score[1].keys.remove(\p1)
+			} {
+				score[1].keys.remove(\bar)
+			};
+			removeKeyword_bar.do { |partName|
 				switch(partName.asString.size,
 					2, { part1 = part1.add(partName) },
 					3, { part2 = part2.add(partName) },


### PR DESCRIPTION
This PR fixes the error reported in #1.

It resolves the issue caused by the Set.remove behaviour introduced in SC3.14.0 through the following PR:
[https://github.com/supercollider/supercollider/pull/6409](https://github.com/supercollider/supercollider/pull/6409?utm_source=copilot.com)